### PR TITLE
Fix JSON syntax errors in recommended permissions example

### DIFF
--- a/plugins/wasp/README.md
+++ b/plugins/wasp/README.md
@@ -61,9 +61,9 @@ For the best experience, add these permissions to your project or user settings:
       "Bash(wasp start)",
       "Bash(wasp db:*)",
       "WebFetch(domain:wasp.sh)",
-      "WebFetch(domain:raw.githubusercontent.com)"
+      "WebFetch(domain:raw.githubusercontent.com)",
       "Skill(wasp:plugin-help)",
-      "Skill(wasp:start-dev-server)",
+      "Skill(wasp:start-dev-server)"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add missing comma after `raw.githubusercontent.com` line
- Remove trailing comma after last array element

The JSON example in the README was invalid - it would fail to parse due to these syntax errors.