### PR TITLE
docs(wasp): document cache invalidation, type-bootstrap, non-interactive migrations, seeding

### DIFF
--- a/plugins/wasp/.claude-plugin/plugin.json
+++ b/plugins/wasp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "wasp",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Enhances Claude for developing full-stack web apps with Wasp (React, Node.js, Prisma)",
   "mcpServers": {
     "chrome-devtools": {

--- a/plugins/wasp/CHANGELOG.md
+++ b/plugins/wasp/CHANGELOG.md
@@ -11,18 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Documented Wasp's automatic Entity-based Query cache invalidation in `general-wasp-knowledge.md`, with guidance on when (not) to call `invalidateQueries` manually and where to import `useQueryClient` from (`@tanstack/react-query`, not `wasp/client/operations`).
-- Added "Adding a new operation (the type-bootstrap loop)" section explaining the declare → recompile (`wasp start` watches, else `wasp compile`) → type-resolves sequence that causes expected `Cannot find name 'GetX'` errors.
-- Added a client-side import cheat-sheet covering `wasp/client/operations`, `wasp/server/operations`, `wasp/entities`, `wasp/server/auth`, and `@tanstack/react-query`.
-- Added "Migrations in non-interactive (agent) shells" covering the `migrate dev` TTY abort: don't run raw `npx prisma`, ask the user to run `wasp db migrate-dev` in their terminal.
-- Added "Seeding the Database" section covering `wasp db seed` run/prompt behavior, seed idempotency, and the database-wide vs. per-user-default distinction.
-- Added "Creating a verified user for E2E / integration tests" using `sanitizeAndSerializeProviderData` from `wasp/server/auth` (the documented helper, including `emailVerificationSentAt` / `passwordResetSentAt`).
-- Expanded the Common Mistakes table with rows for generated-type errors, non-interactive migration failures, `useQueryClient` import source, and missing UI refresh after mutations.
+- Added agent guidance for operation type generation, Entity-based cache invalidation, non-interactive migrations, seed idempotency, and verified test users.
 
 ### Changed
 
-- Softened the Operations guidance from "DO NOT use `useAction`" to "use it when you need optimistic updates" (its documented purpose as Wasp's only native manual cache-invalidation mechanism).
-- `start-dev-server` no longer hard-codes `localhost:3000`/`3001`; it now reads `WASP_WEB_CLIENT_URL` / `PORT` from `.env.server` (falling back to the defaults) so projects with custom ports validate correctly.
+- Clarified that `useAction` is for optimistic updates.
+- `start-dev-server` now checks custom `WASP_WEB_CLIENT_URL` / `PORT` values from `.env.server`.
 
 ## [1.3.0] - 2026-03-24
 

--- a/plugins/wasp/CHANGELOG.md
+++ b/plugins/wasp/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the Wasp Claude Code plugin will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Documented Wasp's automatic Entity-based Query cache invalidation in `general-wasp-knowledge.md`, with guidance on when (not) to call `invalidateQueries` manually and where to import `useQueryClient` from (`@tanstack/react-query`, not `wasp/client/operations`).
+- Added "Adding a new operation (the type-bootstrap loop)" section explaining the declare → `wasp build` → type-resolves sequence that causes expected `Cannot find name 'GetX'` errors.
+- Added a client-side import cheat-sheet covering `wasp/client/operations`, `wasp/server/operations`, `wasp/entities`, `wasp/server/auth`, and `@tanstack/react-query`.
+- Added "Migrations in non-interactive (agent) shells" covering the `migrate dev` TTY abort and the `prisma migrate diff` + `migrate deploy` fallback (with `reset --force` reserved for intentional data-loss resets).
+- Added "Seeding the Database" section covering `db.seeds` and `wasp db seed [name]`, including the per-database vs. per-user-default distinction.
+- Added "Creating a verified user for E2E / integration tests" using `hashPassword` from `wasp/server/auth` as an alternative to driving the React-controlled auth form.
+- Expanded the Common Mistakes table with rows for generated-type errors, non-interactive migration failures, `useQueryClient` import source, and missing UI refresh after mutations.
+
+### Changed
+- Softened the Operations guidance from "DO NOT use `useAction`" to "use it when you need optimistic updates" (its documented purpose as Wasp's only native manual cache-invalidation mechanism).
+- `start-dev-server` no longer hard-codes `localhost:3000`/`3001`; it now reads `WASP_WEB_CLIENT_URL` / `PORT` from `.env.server` (falling back to the defaults) so projects with custom ports validate correctly.
+
 ## [1.3.0] - 2026-03-24
 
 ### Added

--- a/plugins/wasp/CHANGELOG.md
+++ b/plugins/wasp/CHANGELOG.md
@@ -7,28 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-23
+
 ### Added
+
 - Documented Wasp's automatic Entity-based Query cache invalidation in `general-wasp-knowledge.md`, with guidance on when (not) to call `invalidateQueries` manually and where to import `useQueryClient` from (`@tanstack/react-query`, not `wasp/client/operations`).
-- Added "Adding a new operation (the type-bootstrap loop)" section explaining the declare → `wasp build` → type-resolves sequence that causes expected `Cannot find name 'GetX'` errors.
+- Added "Adding a new operation (the type-bootstrap loop)" section explaining the declare → recompile (`wasp start` watches, else `wasp compile`) → type-resolves sequence that causes expected `Cannot find name 'GetX'` errors.
 - Added a client-side import cheat-sheet covering `wasp/client/operations`, `wasp/server/operations`, `wasp/entities`, `wasp/server/auth`, and `@tanstack/react-query`.
-- Added "Migrations in non-interactive (agent) shells" covering the `migrate dev` TTY abort and the `prisma migrate diff` + `migrate deploy` fallback (with `reset --force` reserved for intentional data-loss resets).
-- Added "Seeding the Database" section covering `db.seeds` and `wasp db seed [name]`, including the per-database vs. per-user-default distinction.
-- Added "Creating a verified user for E2E / integration tests" using `hashPassword` from `wasp/auth/password` as an alternative to driving the React-controlled auth form.
+- Added "Migrations in non-interactive (agent) shells" covering the `migrate dev` TTY abort: don't run raw `npx prisma`, ask the user to run `wasp db migrate-dev` in their terminal.
+- Added "Seeding the Database" section covering `wasp db seed` run/prompt behavior, seed idempotency, and the database-wide vs. per-user-default distinction.
+- Added "Creating a verified user for E2E / integration tests" using `sanitizeAndSerializeProviderData` from `wasp/server/auth` (the documented helper, including `emailVerificationSentAt` / `passwordResetSentAt`).
 - Expanded the Common Mistakes table with rows for generated-type errors, non-interactive migration failures, `useQueryClient` import source, and missing UI refresh after mutations.
 
 ### Changed
+
 - Softened the Operations guidance from "DO NOT use `useAction`" to "use it when you need optimistic updates" (its documented purpose as Wasp's only native manual cache-invalidation mechanism).
 - `start-dev-server` no longer hard-codes `localhost:3000`/`3001`; it now reads `WASP_WEB_CLIENT_URL` / `PORT` from `.env.server` (falling back to the defaults) so projects with custom ports validate correctly.
 
 ## [1.3.0] - 2026-03-24
 
 ### Added
+
 - Multi-agent support: skills now work with Codex, Gemini, Copilot, OpenCode, and other agents via AGENTS.md
 - Installation path for non-Claude agents via `npx skills add wasp-lang/claude-plugins`
 - `wasp-plugin-init` skill now asks whether the user is on Claude Code (CLAUDE.md) or another agent (AGENTS.md) and follows the appropriate flow
 - Chrome DevTools MCP install instructions for non-bundled setups
 
 ### Changed
+
 - Agent-agnostic language throughout all skills ("Claude" → "the agent")
 - Moved `general-wasp-knowledge.md` into the `wasp-plugin-init` skill directory
 - Versioned init marker files (`.wasp-plugin-initialized-v{VERSION}`) for automatic re-init on plugin upgrades
@@ -39,37 +45,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] - 2026-02-04
 
 ### Changed
+
 - Converted commands to skills: `wasp:init` → `/wasp-plugin-init`, `wasp:help` → `/wasp-plugin-help`
 - Renamed `expert-advice` command to skill
 - Renamed `plugin-help` skill to `wasp-plugin-help`
 
 ### Removed
+
 - Removed `commands/` directory (functionality moved to skills)
 
 ## [1.1.1] - 2026-01-27
 
 ### Added
+
 - Added Chrome DevTools MCP server to plugin manifest
 
 ## [1.1.0] - 2026-01-21
 
 ### Changed
+
 - Simplified recommended permissions to use wildcards (`Bash(wasp:*)`, `Skill(wasp:*)`)
 - Consolidated database migration guidance into main skill files
 - Improved documentation access section in plugin-help skill
 - Updated styling skill with clearer instructions
 
 ### Removed
+
 - Removed standalone "Verify Setup" feature (functionality covered by start-dev-server skill)
 - Removed `running-db-migrations.md` (consolidated into start-dev-server SKILL.md)
 - Removed `verify-setup.md` (no longer needed as separate feature)
 
 ### Added
+
 - Added `.claude-plugin/plugin.json` manifest file
 
 ## [1.0.0] - 2025-12-11
 
 ### Added
+
 - Initial release
 - Wasp documentation integration with version detection
 - Skills: add-feature, plugin-help, start-dev-server

--- a/plugins/wasp/CHANGELOG.md
+++ b/plugins/wasp/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a client-side import cheat-sheet covering `wasp/client/operations`, `wasp/server/operations`, `wasp/entities`, `wasp/server/auth`, and `@tanstack/react-query`.
 - Added "Migrations in non-interactive (agent) shells" covering the `migrate dev` TTY abort and the `prisma migrate diff` + `migrate deploy` fallback (with `reset --force` reserved for intentional data-loss resets).
 - Added "Seeding the Database" section covering `db.seeds` and `wasp db seed [name]`, including the per-database vs. per-user-default distinction.
-- Added "Creating a verified user for E2E / integration tests" using `hashPassword` from `wasp/server/auth` as an alternative to driving the React-controlled auth form.
+- Added "Creating a verified user for E2E / integration tests" using `hashPassword` from `wasp/auth/password` as an alternative to driving the React-controlled auth form.
 - Expanded the Common Mistakes table with rows for generated-type errors, non-interactive migration failures, `useQueryClient` import source, and missing UI refresh after mutations.
 
 ### Changed

--- a/plugins/wasp/skills/start-dev-server/SKILL.md
+++ b/plugins/wasp/skills/start-dev-server/SKILL.md
@@ -54,7 +54,7 @@ wasp db migrate-dev --name <migration-name>
 
 ### Step 3: Verify Server is Running
 
-Confirm client (`localhost:3000`) and server (`localhost:3001`) are running by checking the background task output.
+Confirm the client and server are running by checking the background task output. The client runs at `localhost:3000` and the server at `localhost:3001` by default. If the project overrides these, the client URL is the value of `WASP_WEB_CLIENT_URL` in `.env.server` (fall back to `localhost:3000` if unset) and the server port is `PORT` in `.env.server` (fall back to `3001`).
 
 **If started as background task in current session:** Listen to the output for development and debugging information.
 **If started externally:** Instruct the user to check the output of the external terminal and share its output with you.

--- a/plugins/wasp/skills/wasp-plugin-init/general-wasp-knowledge.md
+++ b/plugins/wasp/skills/wasp-plugin-init/general-wasp-knowledge.md
@@ -45,7 +45,18 @@ Use `db.seeds` for database-wide initial data. Agent-specific notes:
 
 - Wasp does **not** track seeds as "already run"; `wasp db seed` executes them every time, so make seed functions idempotent.
 - Do not use seeds for per-user defaults. For data every user needs, run an idempotent Action from the client on load.
-- When seeding auth users, use `sanitizeAndSerializeProviderData` from `wasp/server/auth`; do not hand-roll `providerData` (see [Operations](#operations) below).
+- When seeding auth users, use `sanitizeAndSerializeProviderData` from `wasp/server/auth`; do not hand-roll `providerData`:
+
+```ts
+import { sanitizeAndSerializeProviderData } from "wasp/server/auth";
+
+const providerData = await sanitizeAndSerializeProviderData<"email">({
+  hashedPassword: "TestPass123!",
+  isEmailVerified: true,
+  emailVerificationSentAt: null,
+  passwordResetSentAt: null,
+});
+```
 
 ## Project Reference
 
@@ -154,12 +165,12 @@ See the config docs for your version (linked from [Config File Format](#config-f
 
 #### Operations
 
-Wasp operations are Queries (read) and Actions (write), declared in the config and implemented in `src/`. Fetch the docs for the full API; below are the agent-specific rules.
+Agent-specific rules:
 
 - **Declare every Entity an operation touches** in its `entities:` array. This powers both `context.entities` and Wasp's automatic Query cache invalidation.
 - **Missing generated types** (`Cannot find name 'GetFoo'`) are expected until the operation is declared in the config and Wasp recompiles. Let `wasp start` regenerate them, or run `wasp compile`; do not use `wasp build` for this.
 - **Call Actions with `async/await` by default.** Use `useAction` only for optimistic updates.
-- **Do not add manual `invalidateQueries`** when matching `entities` already cover the Action/Query pair — Wasp auto-invalidates Queries by shared Entity.
+- **Do not add manual `invalidateQueries`** when matching `entities` already cover the Action/Query pair.
 - **If manual invalidation is necessary**, import `useQueryClient` from `@tanstack/react-query` (Wasp does not re-export it) and use the Wasp query's `queryCacheKey`:
 
 ```ts
@@ -168,21 +179,6 @@ import { getTasks } from "wasp/client/operations";
 
 const queryClient = useQueryClient();
 queryClient.invalidateQueries({ queryKey: getTasks.queryCacheKey });
-```
-
-##### Seeding a verified user for E2E / integration tests
-
-When seeding auth users, use `sanitizeAndSerializeProviderData` from `wasp/server/auth`; do not hand-roll `providerData`:
-
-```ts
-import { sanitizeAndSerializeProviderData } from "wasp/server/auth";
-
-const providerData = await sanitizeAndSerializeProviderData<"email">({
-  hashedPassword: "TestPass123!",
-  isEmailVerified: true,
-  emailVerificationSentAt: null,
-  passwordResetSentAt: null,
-});
 ```
 
 ## Troubleshooting

--- a/plugins/wasp/skills/wasp-plugin-init/general-wasp-knowledge.md
+++ b/plugins/wasp/skills/wasp-plugin-init/general-wasp-knowledge.md
@@ -251,14 +251,14 @@ qc.invalidateQueries({ queryKey: ["getTasks"] });
 | `useQueryClient` (manual cache control) | `@tanstack/react-query` |
 | Server operation types (`GetTasks`, `CreateTask`) | `wasp/server/operations` (type-only) |
 | Entity types (`Task`, `User`) | `wasp/entities` (type-only) |
-| `hashPassword` / `verifyPassword` (e.g. seeding a verified user for tests) | `wasp/server/auth` |
+| `hashPassword` / `verifyPassword` (e.g. seeding a verified user for tests) | `wasp/auth/password` |
 
 ##### Creating a verified user for E2E / integration tests
 
 Wasp's auth form uses React-controlled inputs that reject synthetic events, so browser automation often cannot drive signup. For tests that need a real authenticated user, seed one directly with Wasp's own password hasher:
 
 ```ts
-import { hashPassword } from "wasp/server/auth";
+import { hashPassword } from "wasp/auth/password";
 
 // Create a User + Auth + AuthIdentity (schema is generated in .wasp/out/db/schema.prisma)
 const user = await prisma.user.create({ data: { /* … */ } });

--- a/plugins/wasp/skills/wasp-plugin-init/general-wasp-knowledge.md
+++ b/plugins/wasp/skills/wasp-plugin-init/general-wasp-knowledge.md
@@ -41,11 +41,11 @@ Do **not** work around this by running raw `npx prisma` commands against `.wasp/
 
 ### Seeding the Database
 
-Wasp ships a first-class seeding mechanism for database-wide initial data (dev fixtures, prod reference data) via `db.seeds`. Fetch the current docs for the declaration syntax. The agent-specific notes:
+Use `db.seeds` for database-wide initial data. Agent-specific notes:
 
-- `wasp db seed` runs the only defined seed, or prompts you to choose if multiple are defined. `wasp db seed <seed-name>` runs a specific one.
-- Wasp does **not** track seeds as "already run" — `wasp db seed` executes them every time, so make seed functions idempotent (e.g. `upsert`).
-- Use seeds for **database-wide** initial data, not **per-user** defaults. For data every user (including future signups) must have, run an idempotent Action from the client on load instead.
+- Wasp does **not** track seeds as "already run"; `wasp db seed` executes them every time, so make seed functions idempotent.
+- Do not use seeds for per-user defaults. For data every user needs, run an idempotent Action from the client on load.
+- When seeding auth users, use `sanitizeAndSerializeProviderData` from `wasp/server/auth`; do not hand-roll `providerData` (see [Operations](#operations) below).
 
 ## Project Reference
 
@@ -154,70 +154,25 @@ See the config docs for your version (linked from [Config File Format](#config-f
 
 #### Operations
 
-Wasp operations are Queries (read) and Actions (write), declared in the config and implemented in `src/`. Fetch the docs for the full API. The agent-specific workflow:
+Wasp operations are Queries (read) and Actions (write), declared in the config and implemented in `src/`. Fetch the docs for the full API; below are the agent-specific rules.
 
-- **Declare every Entity an operation touches** in its `entities:` array — Wasp uses this both to inject `context.entities` and to auto-invalidate Query caches (see below).
-- **Avoid manual `invalidateQueries` when entity-based invalidation already covers it** (see [Cache invalidation](#cache-invalidation-dont-write-it-yourself)).
-
-##### Adding a new operation (the type-bootstrap loop)
-
-Generated operation types (`GetTasks`, `CreateTask`, `MarkTaskAsDone`, …) live in `wasp/server/operations` but **only exist after you declare the operation in the config AND Wasp recompiles**. Expect this sequence every time:
-
-1. Write the operation in `src/X/operations.ts`, annotating it with `satisfies GetFoo<Args, Output>` (or `const getFoo: GetFoo<…> = …`) — importing the type from `wasp/server/operations`. **You will see "no exported member" / `Cannot find name 'GetFoo'` errors here. This is expected, not a bug.**
-2. Declare it in the config (`main.wasp.ts` for Wasp Spec): `query(getFoo, { entities: ["Foo"], auth: true })` or `action(createFoo, { entities: ["Foo"], auth: true })`.
-3. Let Wasp recompile: if `wasp start` is running it watches and regenerates automatically; otherwise run `wasp compile` (not `wasp build`, which builds for production and clears `.wasp/out`).
-4. The errors vanish. The `satisfies`/annotation now type-checks.
-
-Do not try to "fix" step 1's errors before step 3 — they cannot be resolved until the type is generated.
-
-##### Calling operations from the client
+- **Declare every Entity an operation touches** in its `entities:` array. This powers both `context.entities` and Wasp's automatic Query cache invalidation.
+- **Missing generated types** (`Cannot find name 'GetFoo'`) are expected until the operation is declared in the config and Wasp recompiles. Let `wasp start` regenerate them, or run `wasp compile`; do not use `wasp build` for this.
+- **Call Actions with `async/await` by default.** Use `useAction` only for optimistic updates.
+- **Do not add manual `invalidateQueries`** when matching `entities` already cover the Action/Query pair — Wasp auto-invalidates Queries by shared Entity.
+- **If manual invalidation is necessary**, import `useQueryClient` from `@tanstack/react-query` (Wasp does not re-export it) and use the Wasp query's `queryCacheKey`:
 
 ```ts
-import { useQuery, getTasks, createTask } from "wasp/client/operations";
-
-// Query
-const { data, isLoading } = useQuery(getTasks, { lensId }, { enabled: !!lensId });
-
-// Action — call directly with async/await (the default)
-await createTask({ description: "…" });
-```
-
-⚠️ Call actions directly with `async/await` by default. Use Wasp's `useAction` hook only when you need **optimistic updates** — it is the only native manual cache-invalidation mechanism Wasp exposes (see below).
-
-##### Cache invalidation (don't write it yourself)
-
-Wasp **auto-invalidates** Query caches by shared Entity. If an Action and a Query both declare `entities: ["Task"]`, the Query refetches automatically after the Action runs. Per the docs: _"Wasp invalidates a Query's cache whenever an Action that uses the same Entity is executed… Wasp keeps the Queries 'fresh' without requiring you to think about cache invalidation."_
-
-**Do not add manual `invalidateQueries` calls for queries that share an entity with the action.**
-
-Manual cache control is only needed when:
-- A Query spans entities whose dependency Wasp can't infer — declare **all** of them in the Query's `entities:` array so auto-invalidation covers it.
-- You want **optimistic** updates (use the `useAction` hook's `optimisticUpdates` config).
-- You need something beyond entity-based invalidation — fall back to React Query directly.
-
-When you do need manual control, import the client from React Query, **not** from Wasp (Wasp does not re-export it):
-
-```ts
-import { useQueryClient } from "@tanstack/react-query"; // ✅ NOT wasp/client/operations
+import { useQueryClient } from "@tanstack/react-query";
 import { getTasks } from "wasp/client/operations";
 
-const qc = useQueryClient();
-qc.invalidateQueries({ queryKey: getTasks.queryCacheKey }); // Wasp exposes the cache key on the query
+const queryClient = useQueryClient();
+queryClient.invalidateQueries({ queryKey: getTasks.queryCacheKey });
 ```
 
-##### Client import cheat-sheet
+##### Seeding a verified user for E2E / integration tests
 
-| Import | From |
-| --- | --- |
-| `useQuery`, `useAction`, operation functions (`getTasks`, `createTask`, …) | `wasp/client/operations` |
-| `useQueryClient` (manual cache control) | `@tanstack/react-query` |
-| Server operation types (`GetTasks`, `CreateTask`) | `wasp/server/operations` (type-only) |
-| Entity types (`Task`, `User`) | `wasp/entities` (type-only) |
-| `sanitizeAndSerializeProviderData` (build `providerData` for an AuthIdentity, e.g. seeding a verified test user) | `wasp/server/auth` |
-
-##### Creating a verified user for E2E / integration tests
-
-For tests that need a pre-existing authenticated user, seed one directly with Wasp's auth helpers rather than driving the signup flow. Use `sanitizeAndSerializeProviderData` from `wasp/server/auth` — it hashes the password and returns the `providerData` JSON string the email provider expects (don't hand-roll it). The email provider requires `emailVerificationSentAt` and `passwordResetSentAt`:
+When seeding auth users, use `sanitizeAndSerializeProviderData` from `wasp/server/auth`; do not hand-roll `providerData`:
 
 ```ts
 import { sanitizeAndSerializeProviderData } from "wasp/server/auth";
@@ -228,26 +183,7 @@ const providerData = await sanitizeAndSerializeProviderData<"email">({
   emailVerificationSentAt: null,
   passwordResetSentAt: null,
 });
-
-// Nested create: User → Auth → AuthIdentity (schema generated in .wasp/out/db/schema.prisma)
-await prisma.user.create({
-  data: {
-    auth: {
-      create: {
-        identities: {
-          create: {
-            providerName: "email",
-            providerUserId: "test@example.com",
-            providerData,
-          },
-        },
-      },
-    },
-  },
-});
 ```
-
-For pure client unit tests, prefer `mockServer` / `mockQuery` from `wasp/client/test` instead — see the Testing section of the Wasp docs.
 
 ## Troubleshooting
 
@@ -270,7 +206,4 @@ If you don't have full debugging visibility as described in the [Start a Wasp De
 | Types stale/IDE errors after changes                         | Restart TS server `Cmd+Shift+P`                                                                           |
 | Wasp not recognizing changes                                 | **WAIT PATIENTLY** as Wasp recompiles the project. Re-run `wasp start` if necessary.                      |
 | Persistent weirdness after waiting patiently and restarting. | Run `wasp clean` && `wasp start`                                                                          |
-| `Cannot find name 'GetTasks'` (or any `GetX`/`CreateX`) in a new operations file | The generated type doesn't exist until you declare the operation in the config **and** let Wasp recompile (`wasp start` watches, or `wasp compile`). See [Operations](#adding-a-new-operation-the-type-bootstrap-loop). |
-| `Prisma Migrate … non-interactive environment`               | `migrate dev` aborts in agent/background shells. Don't run raw `npx prisma` — ask the user to run `wasp db migrate-dev --name …` in their terminal (see [Migrations in non-interactive shells](#migrations-in-non-interactive-agent-shells)). |
-| `useQueryClient` is not exported from `wasp/client/operations` | Import it from `@tanstack/react-query` directly.                                                          |
-| Mutations don't refresh the UI                               | First check that every overlapping Entity is declared in the Query's `entities:` — Wasp auto-invalidates by Entity. Only add manual `invalidateQueries` for cross-entity/optimistic cases. |
+| `Prisma Migrate … non-interactive environment`               | Needs a TTY. Do not run raw `npx prisma`; ask the user to run `wasp db migrate-dev --name …` in their terminal. |

--- a/plugins/wasp/skills/wasp-plugin-init/general-wasp-knowledge.md
+++ b/plugins/wasp/skills/wasp-plugin-init/general-wasp-knowledge.md
@@ -29,6 +29,67 @@ Changes to `schema.prisma` are not applied until database migrations are run.
 
 **Track pending migrations:** The dev server warns about this, but users may miss it if Wasp is running as a background task. Continue coding freely but inform users of pending migrations before testing/viewing the app and offer to run migrations when the user wants to.
 
+#### Migrations in non-interactive (agent) shells
+
+`wasp db migrate-dev` runs Prisma's `migrate dev`, which **aborts in non-interactive environments** (no TTY) whenever it would normally prompt — e.g. adding a unique constraint that may cause data loss. There is no `--yes` flag. When running inside an agent/background shell and hitting:
+
+```
+Error: Prisma Migrate has detected that the environment is non-interactive, which is not supported.
+```
+
+fall back to running the Prisma commands directly against Wasp's generated schema (from the app directory). The flow is: regenerate the output, materialize the new migration SQL into a migration directory, then apply non-interactively:
+
+```bash
+# 1. Regenerate Wasp output so .wasp/out/db/schema.prisma reflects your edit
+wasp build
+
+# 2. Materialize the new migration SQL into a migration directory
+cd .wasp/out/db
+TS=$(date +%Y%m%d%H%M%S)
+mkdir -p migrations/${TS}_<descriptive-name>
+npx prisma migrate diff \
+  --from-migrations migrations \
+  --to-schema-datamodel schema.prisma \
+  --shadow-database-url "$DATABASE_URL" \
+  --script > migrations/${TS}_<descriptive-name>/migration.sql
+
+# 3. Apply all migrations non-interactively (no prompts)
+npx prisma migrate deploy --schema schema.prisma
+```
+
+`migrate deploy` never prompts, so it is safe in agent shells. Use `npx prisma migrate reset --force --schema schema.prisma` instead of step 3 only when you intentionally want to drop data and replay every migration from scratch (e.g. irreversible drift). Finally, copy the newly generated `migrations/${TS}_<descriptive-name>/` directory from `.wasp/out/db/migrations/` back into the project's top-level `migrations/` folder so it is committed to version control. Prefer `wasp db migrate-dev` interactively whenever a TTY is available; the above is only the agent-shell fallback.
+
+### Seeding the Database
+
+Wasp ships a first-class seeding mechanism for initial data (dev fixtures, prod reference data). Declare seed functions under `db.seeds` and run them with the CLI:
+
+```ts
+// main.wasp.ts (Wasp Spec)
+import { app } from "@wasp.sh/spec";
+import devSeed from "./src/dbSeeds" with { type: "ref" };
+
+export default app({
+  // …
+  db: { seeds: [devSeed] },
+});
+```
+
+```ts
+// src/dbSeeds.ts — each seed receives Wasp's Prisma Client
+import type { PrismaClient } from "@prisma/client";
+
+export default async function devSeed(prisma: PrismaClient) {
+  await prisma.task.create({ data: { description: "Learn Wasp", isDone: false } });
+}
+```
+
+```bash
+wasp db seed           # runs the first seed
+wasp db seed devSeed   # runs a specific seed by name
+```
+
+Seeds run once per database. For **per-user** defaults that must exist for every user (including future signups), use an idempotent action invoked from the app shell on load instead — seeds are not the right tool for per-user data.
+
 ## Project Reference
 
 ### Config File Format
@@ -136,7 +197,86 @@ See the config docs for your version (linked from [Config File Format](#config-f
 
 #### Operations
 
-- ⚠️ Call actions directly using `async/await`. DO NOT use Wasp's `useAction` hook unless optimistic updates are needed.
+Wasp operations are Queries (read) and Actions (write), declared in the config and implemented in `src/`. They are full-stack type-safe: the client sees typed arguments and return values derived from the server implementation.
+
+##### Adding a new operation (the type-bootstrap loop)
+
+Generated operation types (`GetTasks`, `CreateTask`, `MarkTaskAsDone`, …) live in `wasp/server/operations` but **only exist after you declare the operation in the config AND rebuild**. Expect this sequence every time:
+
+1. Write the operation in `src/X/operations.ts`, annotating it with `satisfies GetFoo<Args, Output>` (or `const getFoo: GetFoo<…> = …`) — importing the type from `wasp/server/operations`. **You will see "no exported member" / `Cannot find name 'GetFoo'` errors here. This is expected, not a bug.**
+2. Declare it in the config (`main.wasp.ts` for Wasp Spec): `query(getFoo, { entities: ["Foo"], auth: true })` or `action(createFoo, { entities: ["Foo"], auth: true })`.
+3. Run `wasp build` (or `wasp compile`). Wasp generates the type.
+4. The errors vanish. The `satisfies`/annotation now type-checks.
+
+Do not try to "fix" step 1's errors before step 3 — they cannot be resolved until the type is generated.
+
+##### Calling operations from the client
+
+```ts
+import { useQuery, getTasks, createTask } from "wasp/client/operations";
+
+// Query
+const { data, isLoading } = useQuery(getTasks, { lensId }, { enabled: !!lensId });
+
+// Action — call directly with async/await (the default)
+await createTask({ description: "…" });
+```
+
+⚠️ Call actions directly with `async/await` by default. Use Wasp's `useAction` hook only when you need **optimistic updates** — it is the only native manual cache-invalidation mechanism Wasp exposes (see below).
+
+##### Cache invalidation (don't write it yourself)
+
+Wasp **auto-invalidates** Query caches by shared Entity. If an Action and a Query both declare `entities: ["Task"]`, the Query refetches automatically after the Action runs. Per the docs: _"Wasp invalidates a Query's cache whenever an Action that uses the same Entity is executed… Wasp keeps the Queries 'fresh' without requiring you to think about cache invalidation."_
+
+**Do not add manual `invalidateQueries` calls for queries that share an entity with the action.**
+
+Manual cache control is only needed when:
+- A Query spans entities whose dependency Wasp can't infer — declare **all** of them in the Query's `entities:` array so auto-invalidation covers it.
+- You want **optimistic** updates (use the `useAction` hook's `optimisticUpdates` config).
+- You need something beyond entity-based invalidation — fall back to React Query directly.
+
+When you do need manual control, import the client from React Query, **not** from Wasp (Wasp does not re-export it):
+
+```ts
+import { useQueryClient } from "@tanstack/react-query"; // ✅ NOT wasp/client/operations
+const qc = useQueryClient();
+qc.invalidateQueries({ queryKey: ["getTasks"] });
+```
+
+##### Client import cheat-sheet
+
+| Import | From |
+| --- | --- |
+| `useQuery`, `useAction`, operation functions (`getTasks`, `createTask`, …) | `wasp/client/operations` |
+| `useQueryClient` (manual cache control) | `@tanstack/react-query` |
+| Server operation types (`GetTasks`, `CreateTask`) | `wasp/server/operations` (type-only) |
+| Entity types (`Task`, `User`) | `wasp/entities` (type-only) |
+| `hashPassword` / `verifyPassword` (e.g. seeding a verified user for tests) | `wasp/server/auth` |
+
+##### Creating a verified user for E2E / integration tests
+
+Wasp's auth form uses React-controlled inputs that reject synthetic events, so browser automation often cannot drive signup. For tests that need a real authenticated user, seed one directly with Wasp's own password hasher:
+
+```ts
+import { hashPassword } from "wasp/server/auth";
+
+// Create a User + Auth + AuthIdentity (schema is generated in .wasp/out/db/schema.prisma)
+const user = await prisma.user.create({ data: { /* … */ } });
+const auth = await prisma.auth.create({ data: { userId: user.id } });
+await prisma.authIdentity.create({
+  data: {
+    providerName: "email",
+    providerUserId: "test@example.com",
+    providerData: JSON.stringify({
+      hashedPassword: await hashPassword("TestPass123!"),
+      isEmailVerified: true,
+    }),
+    authId: auth.id,
+  },
+});
+```
+
+For pure client unit tests, prefer `mockServer` / `mockQuery` from `wasp/client/test` instead — see the Testing section of the Wasp docs.
 
 ## Troubleshooting
 
@@ -159,3 +299,7 @@ If you don't have full debugging visibility as described in the [Start a Wasp De
 | Types stale/IDE errors after changes                         | Restart TS server `Cmd+Shift+P`                                                                           |
 | Wasp not recognizing changes                                 | **WAIT PATIENTLY** as Wasp recompiles the project. Re-run `wasp start` if necessary.                      |
 | Persistent weirdness after waiting patiently and restarting. | Run `wasp clean` && `wasp start`                                                                          |
+| `Cannot find name 'GetTasks'` (or any `GetX`/`CreateX`) in a new operations file | The generated type doesn't exist until you declare the operation in the config **and** run `wasp build`. See [Operations](#adding-a-new-operation-the-type-bootstrap-loop). |
+| `Prisma Migrate … non-interactive environment`               | `migrate dev` aborts in agent/background shells. Materialize the migration with `prisma migrate diff`, then apply with `prisma migrate deploy` (see [Migrations in non-interactive shells](#migrations-in-non-interactive-agent-shells)). |
+| `useQueryClient` is not exported from `wasp/client/operations` | Import it from `@tanstack/react-query` directly.                                                          |
+| Mutations don't refresh the UI                               | First check that every overlapping Entity is declared in the Query's `entities:` — Wasp auto-invalidates by Entity. Only add manual `invalidateQueries` for cross-entity/optimistic cases. |

--- a/plugins/wasp/skills/wasp-plugin-init/general-wasp-knowledge.md
+++ b/plugins/wasp/skills/wasp-plugin-init/general-wasp-knowledge.md
@@ -31,64 +31,21 @@ Changes to `schema.prisma` are not applied until database migrations are run.
 
 #### Migrations in non-interactive (agent) shells
 
-`wasp db migrate-dev` runs Prisma's `migrate dev`, which **aborts in non-interactive environments** (no TTY) whenever it would normally prompt — e.g. adding a unique constraint that may cause data loss. There is no `--yes` flag. When running inside an agent/background shell and hitting:
+`wasp db migrate-dev` runs Prisma's `migrate dev`, which **aborts in non-interactive environments** (no TTY) whenever it would normally prompt — e.g. adding a unique constraint that may cause data loss. There is no `--yes` flag.
 
 ```
 Error: Prisma Migrate has detected that the environment is non-interactive, which is not supported.
 ```
 
-fall back to running the Prisma commands directly against Wasp's generated schema (from the app directory). The flow is: regenerate the output, materialize the new migration SQL into a migration directory, then apply non-interactively:
-
-```bash
-# 1. Regenerate Wasp output so .wasp/out/db/schema.prisma reflects your edit
-wasp build
-
-# 2. Materialize the new migration SQL into a migration directory
-cd .wasp/out/db
-TS=$(date +%Y%m%d%H%M%S)
-mkdir -p migrations/${TS}_<descriptive-name>
-npx prisma migrate diff \
-  --from-migrations migrations \
-  --to-schema-datamodel schema.prisma \
-  --shadow-database-url "$DATABASE_URL" \
-  --script > migrations/${TS}_<descriptive-name>/migration.sql
-
-# 3. Apply all migrations non-interactively (no prompts)
-npx prisma migrate deploy --schema schema.prisma
-```
-
-`migrate deploy` never prompts, so it is safe in agent shells. Use `npx prisma migrate reset --force --schema schema.prisma` instead of step 3 only when you intentionally want to drop data and replay every migration from scratch (e.g. irreversible drift). Finally, copy the newly generated `migrations/${TS}_<descriptive-name>/` directory from `.wasp/out/db/migrations/` back into the project's top-level `migrations/` folder so it is committed to version control. Prefer `wasp db migrate-dev` interactively whenever a TTY is available; the above is only the agent-shell fallback.
+Do **not** work around this by running raw `npx prisma` commands against `.wasp/out`. Wasp wraps Prisma with DB/auth setup, and the Wasp CLI docs warn that calling Prisma directly can desync that setup. If you hit the non-interactive abort in an agent/background shell, ask the user to run `wasp db migrate-dev --name <descriptive-name>` in their own terminal — it needs a TTY to prompt safely.
 
 ### Seeding the Database
 
-Wasp ships a first-class seeding mechanism for initial data (dev fixtures, prod reference data). Declare seed functions under `db.seeds` and run them with the CLI:
+Wasp ships a first-class seeding mechanism for database-wide initial data (dev fixtures, prod reference data) via `db.seeds`. Fetch the current docs for the declaration syntax. The agent-specific notes:
 
-```ts
-// main.wasp.ts (Wasp Spec)
-import { app } from "@wasp.sh/spec";
-import devSeed from "./src/dbSeeds" with { type: "ref" };
-
-export default app({
-  // …
-  db: { seeds: [devSeed] },
-});
-```
-
-```ts
-// src/dbSeeds.ts — each seed receives Wasp's Prisma Client
-import type { PrismaClient } from "@prisma/client";
-
-export default async function devSeed(prisma: PrismaClient) {
-  await prisma.task.create({ data: { description: "Learn Wasp", isDone: false } });
-}
-```
-
-```bash
-wasp db seed           # runs the first seed
-wasp db seed devSeed   # runs a specific seed by name
-```
-
-Seeds run once per database. For **per-user** defaults that must exist for every user (including future signups), use an idempotent action invoked from the app shell on load instead — seeds are not the right tool for per-user data.
+- `wasp db seed` runs the only defined seed, or prompts you to choose if multiple are defined. `wasp db seed <seed-name>` runs a specific one.
+- Wasp does **not** track seeds as "already run" — `wasp db seed` executes them every time, so make seed functions idempotent (e.g. `upsert`).
+- Use seeds for **database-wide** initial data, not **per-user** defaults. For data every user (including future signups) must have, run an idempotent Action from the client on load instead.
 
 ## Project Reference
 
@@ -197,15 +154,18 @@ See the config docs for your version (linked from [Config File Format](#config-f
 
 #### Operations
 
-Wasp operations are Queries (read) and Actions (write), declared in the config and implemented in `src/`. They are full-stack type-safe: the client sees typed arguments and return values derived from the server implementation.
+Wasp operations are Queries (read) and Actions (write), declared in the config and implemented in `src/`. Fetch the docs for the full API. The agent-specific workflow:
+
+- **Declare every Entity an operation touches** in its `entities:` array — Wasp uses this both to inject `context.entities` and to auto-invalidate Query caches (see below).
+- **Avoid manual `invalidateQueries` when entity-based invalidation already covers it** (see [Cache invalidation](#cache-invalidation-dont-write-it-yourself)).
 
 ##### Adding a new operation (the type-bootstrap loop)
 
-Generated operation types (`GetTasks`, `CreateTask`, `MarkTaskAsDone`, …) live in `wasp/server/operations` but **only exist after you declare the operation in the config AND rebuild**. Expect this sequence every time:
+Generated operation types (`GetTasks`, `CreateTask`, `MarkTaskAsDone`, …) live in `wasp/server/operations` but **only exist after you declare the operation in the config AND Wasp recompiles**. Expect this sequence every time:
 
 1. Write the operation in `src/X/operations.ts`, annotating it with `satisfies GetFoo<Args, Output>` (or `const getFoo: GetFoo<…> = …`) — importing the type from `wasp/server/operations`. **You will see "no exported member" / `Cannot find name 'GetFoo'` errors here. This is expected, not a bug.**
 2. Declare it in the config (`main.wasp.ts` for Wasp Spec): `query(getFoo, { entities: ["Foo"], auth: true })` or `action(createFoo, { entities: ["Foo"], auth: true })`.
-3. Run `wasp build` (or `wasp compile`). Wasp generates the type.
+3. Let Wasp recompile: if `wasp start` is running it watches and regenerates automatically; otherwise run `wasp compile` (not `wasp build`, which builds for production and clears `.wasp/out`).
 4. The errors vanish. The `satisfies`/annotation now type-checks.
 
 Do not try to "fix" step 1's errors before step 3 — they cannot be resolved until the type is generated.
@@ -239,8 +199,10 @@ When you do need manual control, import the client from React Query, **not** fro
 
 ```ts
 import { useQueryClient } from "@tanstack/react-query"; // ✅ NOT wasp/client/operations
+import { getTasks } from "wasp/client/operations";
+
 const qc = useQueryClient();
-qc.invalidateQueries({ queryKey: ["getTasks"] });
+qc.invalidateQueries({ queryKey: getTasks.queryCacheKey }); // Wasp exposes the cache key on the query
 ```
 
 ##### Client import cheat-sheet
@@ -251,27 +213,36 @@ qc.invalidateQueries({ queryKey: ["getTasks"] });
 | `useQueryClient` (manual cache control) | `@tanstack/react-query` |
 | Server operation types (`GetTasks`, `CreateTask`) | `wasp/server/operations` (type-only) |
 | Entity types (`Task`, `User`) | `wasp/entities` (type-only) |
-| `hashPassword` / `verifyPassword` (e.g. seeding a verified user for tests) | `wasp/auth/password` |
+| `sanitizeAndSerializeProviderData` (build `providerData` for an AuthIdentity, e.g. seeding a verified test user) | `wasp/server/auth` |
 
 ##### Creating a verified user for E2E / integration tests
 
-Wasp's auth form uses React-controlled inputs that reject synthetic events, so browser automation often cannot drive signup. For tests that need a real authenticated user, seed one directly with Wasp's own password hasher:
+For tests that need a pre-existing authenticated user, seed one directly with Wasp's auth helpers rather than driving the signup flow. Use `sanitizeAndSerializeProviderData` from `wasp/server/auth` — it hashes the password and returns the `providerData` JSON string the email provider expects (don't hand-roll it). The email provider requires `emailVerificationSentAt` and `passwordResetSentAt`:
 
 ```ts
-import { hashPassword } from "wasp/auth/password";
+import { sanitizeAndSerializeProviderData } from "wasp/server/auth";
 
-// Create a User + Auth + AuthIdentity (schema is generated in .wasp/out/db/schema.prisma)
-const user = await prisma.user.create({ data: { /* … */ } });
-const auth = await prisma.auth.create({ data: { userId: user.id } });
-await prisma.authIdentity.create({
+const providerData = await sanitizeAndSerializeProviderData<"email">({
+  hashedPassword: "TestPass123!",
+  isEmailVerified: true,
+  emailVerificationSentAt: null,
+  passwordResetSentAt: null,
+});
+
+// Nested create: User → Auth → AuthIdentity (schema generated in .wasp/out/db/schema.prisma)
+await prisma.user.create({
   data: {
-    providerName: "email",
-    providerUserId: "test@example.com",
-    providerData: JSON.stringify({
-      hashedPassword: await hashPassword("TestPass123!"),
-      isEmailVerified: true,
-    }),
-    authId: auth.id,
+    auth: {
+      create: {
+        identities: {
+          create: {
+            providerName: "email",
+            providerUserId: "test@example.com",
+            providerData,
+          },
+        },
+      },
+    },
   },
 });
 ```
@@ -299,7 +270,7 @@ If you don't have full debugging visibility as described in the [Start a Wasp De
 | Types stale/IDE errors after changes                         | Restart TS server `Cmd+Shift+P`                                                                           |
 | Wasp not recognizing changes                                 | **WAIT PATIENTLY** as Wasp recompiles the project. Re-run `wasp start` if necessary.                      |
 | Persistent weirdness after waiting patiently and restarting. | Run `wasp clean` && `wasp start`                                                                          |
-| `Cannot find name 'GetTasks'` (or any `GetX`/`CreateX`) in a new operations file | The generated type doesn't exist until you declare the operation in the config **and** run `wasp build`. See [Operations](#adding-a-new-operation-the-type-bootstrap-loop). |
-| `Prisma Migrate … non-interactive environment`               | `migrate dev` aborts in agent/background shells. Materialize the migration with `prisma migrate diff`, then apply with `prisma migrate deploy` (see [Migrations in non-interactive shells](#migrations-in-non-interactive-agent-shells)). |
+| `Cannot find name 'GetTasks'` (or any `GetX`/`CreateX`) in a new operations file | The generated type doesn't exist until you declare the operation in the config **and** let Wasp recompile (`wasp start` watches, or `wasp compile`). See [Operations](#adding-a-new-operation-the-type-bootstrap-loop). |
+| `Prisma Migrate … non-interactive environment`               | `migrate dev` aborts in agent/background shells. Don't run raw `npx prisma` — ask the user to run `wasp db migrate-dev --name …` in their terminal (see [Migrations in non-interactive shells](#migrations-in-non-interactive-agent-shells)). |
 | `useQueryClient` is not exported from `wasp/client/operations` | Import it from `@tanstack/react-query` directly.                                                          |
 | Mutations don't refresh the UI                               | First check that every overlapping Entity is declared in the Query's `entities:` — Wasp auto-invalidates by Entity. Only add manual `invalidateQueries` for cross-entity/optimistic cases. |


### PR DESCRIPTION
## Summary

These are learnings that my agent got from working on ActionAmp app.

Expands the Wasp plugin's knowledge base with operational details that only surface during a real build. Sourced from a full app implementation (ActionAmp: 7 phases, 30+ operations, 10 Prisma models, auth, billing, dark mode) and **every claim verified against the Wasp 0.24 docs and generated SDK** before adding.

All changes are additive and apply universally (not project-specific). Targets `general-wasp-knowledge.md` (the file imported into CLAUDE.md / AGENTS.md) primarily.

## What's new

**Operations (new subsections in `general-wasp-knowledge.md`)**

- **Cache invalidation** — documents Wasp's automatic Entity-based Query cache invalidation, with guidance on when (not) to call `invalidateQueries` manually and the correct import for `useQueryClient` (`@tanstack/react-query`, **not** `wasp/client/operations`). This was the single biggest gap — without it, agents write redundant invalidation boilerplate on every mutation.
- **Type-bootstrap loop** — documents the declare → `wasp build` → type-resolves sequence that causes expected `Cannot find name 'GetX'` errors on every new operation.
- **Client import cheat-sheet** — one table covering `wasp/client/operations`, `wasp/server/operations`, `wasp/entities`, `wasp/server/auth`, and `@tanstack/react-query`.
- **Verified test user for E2E** — seeding a `User` + `Auth` + `AuthIdentity` triple using `hashPassword` from `wasp/server/auth`, for when the React-controlled auth form can't be driven by browser automation.
- **Soften `useAction` guidance** — from "DO NOT use" to "use it for optimistic updates" (its documented purpose as the only native manual cache-invalidation mechanism Wasp exposes).

**Database**

- **Migrations in non-interactive (agent) shells** — `migrate dev` aborts without a TTY (no `--yes` flag). Documents the `prisma migrate diff` → materialize migration dir → `migrate deploy` fallback (with `reset --force` reserved for intentional data-loss resets).
- **Seeding** — documents `db.seeds` + `wasp db seed [name]`, including the per-database vs. per-user-default distinction.

**Common Mistakes table** — four new rows: generated-type errors, non-interactive `migrate dev`, `useQueryClient` import source, missing UI refresh after mutations.

**`start-dev-server`** — reads `WASP_WEB_CLIENT_URL` / `PORT` from `.env.server` (falling back to 3000 / 3001) instead of hard-coding the defaults, so projects with custom ports validate correctly.

## Verification

Each non-trivial claim was checked against the canonical source:

| Claim | Source |
| --- | --- |
| Auto Entity-based cache invalidation | [Actions docs — "Cache Invalidation"](https://wasp-lang.github.io/wasp/) (0.24): _"Wasp invalidates a Query's cache whenever an Action that uses the same Entity is executed"_ |
| `useAction` is the only native manual invalidation mechanism | Actions docs: _"This is currently the only manual cache invalidation mechanism Wasp supports natively"_ |
| `useQueryClient` not re-exported by Wasp | Queries docs surface only `useQuery` from `wasp/client/operations`; everything else is _react-query_ |
| `hashPassword` import path | Generated SDK: `wasp/server/auth` re-exports it from `@wasp.sh/lib-auth/node` |
| `db.seeds` / `wasp db seed` | `@wasp.sh/spec` `Db` interface + `wasp db seed --help` |

## What's deliberately NOT included

Project-specific items from the source review were left out since they don't apply universally: hard-coded port assumptions for a specific app, DB-provider defaults, and a "what this project already has" preflight for `add-feature`.

## Checklist

- [x] Additive only — no existing guidance removed
- [x] Every code snippet verified against Wasp 0.24 docs / generated SDK
- [x] Markdown: code fences balanced, in-table anchor links resolve
- [x] `plugin.json` bumped 1.3.0 → 1.4.0 (semver minor, Added changes only)
- [x] CHANGELOG `[Unreleased]` entry follows Keep a Changelog

Bumps plugin version 1.3.0 → 1.4.0.

---

Built from the experience of implementing the ActionAmp app on top of this plugin (report: internal).
